### PR TITLE
Update Header Styling for Password Reset

### DIFF
--- a/apps/web/src/pages/PasswordResetPage/PasswordResetPage.tsx
+++ b/apps/web/src/pages/PasswordResetPage/PasswordResetPage.tsx
@@ -59,9 +59,7 @@ export default function PasswordResetPage(): JSX.Element {
         {/* Header */}
         <div className="sm:mx-auto sm:w-full sm:max-w-md">
           <img className="mx-auto h-12 w-auto" src={logo} alt="wya? logo" />
-          <h2 className="mt-6 text-center text-3xl font-extrabold text-gray-900">
-            Password Reset
-          </h2>
+          <h1 className="pt-4 flex justify-center">Password Reset</h1>
         </div>
 
         {/* Negative Alert Banner */}


### PR DESCRIPTION
Couldn't figure out how to delete the year from the heatmap. I know it's on AvailabilityHeatMap.tsx between lines 25-56 but I can't figure out where I can edit it. If anyone else can figure it out I'd be super appreciative. For this PR I only changed the header on the Password Reset Page when logged out so that it matched our other headers. 